### PR TITLE
Makefile: make GBDIR able to be overloaded on the command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #CROSS_COMPILE = arm-linux-gnueabi-
  
 # Location of Greybus kernel headers
-GBDIR = /home/mporter/src/greybus
+GBDIR ?= /home/mporter/src/greybus
 
 # Install directory
 INSTALLDIR = /usr/local/bin


### PR DESCRIPTION
Only use the default version if there is not an environment variable
version.

Signed-off-by: Greg Kroah-Hartman greg@kroah.com
